### PR TITLE
Feat/draw logic changes

### DIFF
--- a/src/grading/Feedback.tsx
+++ b/src/grading/Feedback.tsx
@@ -249,7 +249,7 @@ const Feedback: React.FC<feedbackProps> = (props) => {
                   <button
                   onClick={() => {
                     
-                    if(props.clearKanji)  props.clearKanji() 
+                    props.clearKanji!()
                   }}
                   className="learn-card-nav-right"
                 >

--- a/src/grading/Feedback.tsx
+++ b/src/grading/Feedback.tsx
@@ -87,7 +87,7 @@ const Feedback: React.FC<feedbackProps> = (props) => {
     }
  }, [childIndex]);
 
- const displayRetryText = useMemo(() => {
+ const displayRetryButton = useMemo(() => {
   //If not in recall mode (ex dictionary page), don't show button
   if(!props.recall) {
     return false;
@@ -239,17 +239,23 @@ const Feedback: React.FC<feedbackProps> = (props) => {
                   <div className="feedback-word">
                     {gradeToWord(Math.round(kanji_grade.overallGrade))}
                   </div>
-                  {displayRetryText &&
-                <div>
-                  <strong>Please retry without the kanji guide to advance.</strong>
-                </div>
-}
+                  
                   
                 </div>
                 
                 </div>
                 
-                
+                {displayRetryButton &&(
+                  <button
+                  onClick={() => {
+                    
+                    if(props.clearKanji)  props.clearKanji() 
+                  }}
+                  className="learn-card-nav-right"
+                >
+                  <ArrowForward />
+                </button>
+                )}
                 {displayNextButton && (
                   <button
                     onClick={() => {

--- a/src/grading/Feedback.tsx
+++ b/src/grading/Feedback.tsx
@@ -7,7 +7,6 @@ import { gradeToWord } from "../utils/gradeToColor";
 import ArrowForward from "@mui/icons-material/ArrowForward";
 import Character from "../types/Character";
 import { debounce } from "lodash";
-import UndoIcon from '@mui/icons-material/Undo';
 
 interface feedbackProps {
   kanjiGrade: KanjiGrade;
@@ -256,7 +255,7 @@ const Feedback: React.FC<feedbackProps> = (props) => {
                   }}
                   className="learn-card-nav-right"
                 >
-                  <UndoIcon />
+                  <ArrowForward />
                 </button>
                 )}
                 {displayNextButton && (

--- a/src/grading/Feedback.tsx
+++ b/src/grading/Feedback.tsx
@@ -7,6 +7,7 @@ import { gradeToWord } from "../utils/gradeToColor";
 import ArrowForward from "@mui/icons-material/ArrowForward";
 import Character from "../types/Character";
 import { debounce } from "lodash";
+import UndoIcon from '@mui/icons-material/Undo';
 
 interface feedbackProps {
   kanjiGrade: KanjiGrade;
@@ -253,7 +254,7 @@ const Feedback: React.FC<feedbackProps> = (props) => {
                   }}
                   className="learn-card-nav-right"
                 >
-                  <ArrowForward />
+                  <UndoIcon />
                 </button>
                 )}
                 {displayNextButton && (

--- a/src/grading/Feedback.tsx
+++ b/src/grading/Feedback.tsx
@@ -86,6 +86,32 @@ const Feedback: React.FC<feedbackProps> = (props) => {
       }, 400) 
     }
  }, [childIndex]);
+
+ const displayRetryText = useMemo(() => {
+  //If not in recall mode (ex dictionary page), don't show button
+  if(!props.recall) {
+    return false;
+  }
+
+  //Learn Mode
+  if(props.learn) {
+    const attemptsWithHint = props.attempts.filter((grade) => grade.overallGrade > 65 && grade.hint)
+    const passingWithoutHint = props.attempts.filter((grade) => grade.overallGrade > 65 && !grade.hint)
+    debugger;
+
+    if(attemptsWithHint.length >= 1 && passingWithoutHint.length ===0 && !props.allowDisplay) {
+      return props.kanjiGrade // true
+    }
+    else {
+      return false
+    }
+  } 
+  //Review Mode
+  else {
+    return props.kanjiGrade && props.kanjiGrade.overallGrade > 65 
+  }
+  
+},[props.attempts, props.allowDisplay])
   
 
   const displayNextButton = useMemo(() => {
@@ -213,8 +239,14 @@ const Feedback: React.FC<feedbackProps> = (props) => {
                   <div className="feedback-word">
                     {gradeToWord(Math.round(kanji_grade.overallGrade))}
                   </div>
+                  {displayRetryText &&
+                <div>
+                  <strong>Please retry without the kanji guide to advance.</strong>
+                </div>
+}
                   
                 </div>
+                
                 </div>
                 
                 

--- a/src/grading/Feedback.tsx
+++ b/src/grading/Feedback.tsx
@@ -10,10 +10,11 @@ import { debounce } from "lodash";
 
 interface feedbackProps {
   kanjiGrade: KanjiGrade;
-  attempts: KanjiGrade[];
+  attempts: (KanjiGrade & {hint:boolean})[];
   character: Character;
   setAllowDisplay: React.Dispatch<React.SetStateAction<boolean>>;
   setDisplaySVG: React.Dispatch<React.SetStateAction<boolean>>;
+  allowDisplay: boolean;
 
   passing: number;
   color: string;
@@ -95,7 +96,7 @@ const Feedback: React.FC<feedbackProps> = (props) => {
 
     //Learn Mode
     if(props.learn) {
-      if(props.attempts.length > 1) {
+      if(props.attempts.filter((grade) => grade.overallGrade > 65 && !grade.hint).length > 0) {
         return props.kanjiGrade 
       }
     } 
@@ -212,11 +213,7 @@ const Feedback: React.FC<feedbackProps> = (props) => {
                   <div className="feedback-word">
                     {gradeToWord(Math.round(kanji_grade.overallGrade))}
                   </div>
-                  {props.learn && props.attempts.length === 1 &&
-                    <div className="feedback-word">
-                    <strong>Try again without the kanji to continue</strong>
-                  </div>
-                  }
+                  
                 </div>
                 </div>
                 

--- a/src/pages/Draw.tsx
+++ b/src/pages/Draw.tsx
@@ -99,7 +99,7 @@ const Draw: React.FC<DrawProps> = (props) => {
     strokeInfo: [],
   });
 
-  const [attempts, setAttempts] = React.useState<KanjiGrade[]>([]);
+  const [attempts, setAttempts] = React.useState<(KanjiGrade & {hint: boolean})[]>([]);
 
   function clearKanji() {
     canvas.current.clearCanvas();
@@ -359,19 +359,42 @@ const Draw: React.FC<DrawProps> = (props) => {
               }
                 grade(data, kanji, passing, convertCoords(character?.coords),character?.totalLengths).then((grade: KanjiGrade) => {
 
-                  setKanjiGrade(grade);
+                setKanjiGrade(grade)
+                  setAttempts((prevAttempts) => {
+                    const attempts =  [...prevAttempts,{...grade, hint: allowDisplaySVG}]
+                    if(props.learn) {
+                      const some = attempts.some((grade) => grade.overallGrade > 65 && !grade.hint)
+                      if(!some) {
+                        if(allowDisplaySVG) {
+                          debugger;
+                          if(grade.overallGrade > 65) {
+                            setAllowDisplaySVG(false)
+                            setDisplaySVG(false)
+                          }
+                          
+                        }
+                        else {
+                          debugger;
+                          setAllowDisplaySVG(true)
+                          setDisplaySVG(true)
+                        }
+                      }
+                      else {
+                        debugger;
+                        setAllowDisplaySVG(true)
+                        setDisplaySVG(true)
+                      }
+                        
+                        
+                      
+                     
+                      
+                    }
+                    return attempts
+                  } )
                   //If in learn mode, hide svg on second attempt
-                  if(props.learn) {
-                    if(attempts.length === 0) {
-                      setAllowDisplaySVG(false)
-                      setDisplaySVG(false)
-                    }
-                    else if(!allowDisplaySVG){
-                      setAllowDisplaySVG(true)
-                    }
-                    
-                  }
-                  setAttempts((prevAttempts) => [...prevAttempts,grade])
+                  
+
                   if(props.character) {
                     if(props.handleComplete) {
                       props.handleComplete(props.character,grade)
@@ -429,7 +452,7 @@ const Draw: React.FC<DrawProps> = (props) => {
         </button>
         }
       </div>
-      <Feedback setDisplaySVG={setDisplaySVG} setAllowDisplay={setAllowDisplaySVG} clearKanji={clearKanji} attempts={attempts} recall={props.recall} learn={props.learn || false} character={props.character!} handleAdvance={handleAdvance} handleComplete={props.handleComplete} kanjiGrade={kanji_grade} passing={passing} color={color} />
+      <Feedback setDisplaySVG={setDisplaySVG} setAllowDisplay={setAllowDisplaySVG} clearKanji={clearKanji} allowDisplay={allowDisplaySVG} attempts={attempts} recall={props.recall} learn={props.learn || false} character={props.character!} handleAdvance={handleAdvance} handleComplete={props.handleComplete} kanjiGrade={kanji_grade} passing={passing} color={color} />
     </div>
 
   );

--- a/src/pages/Draw.tsx
+++ b/src/pages/Draw.tsx
@@ -322,43 +322,42 @@ const Draw: React.FC<DrawProps> = (props) => {
             {displaySVG ? <VisibilityOffIcon fontSize="medium" /> : <VisibilityIcon fontSize="medium" />}
           </button>
         )}
+        {kanji_grade.overallGrade !== -1 ?
+          <button
+            className="check-kanji"
+            style={styles.button}
+            onClick={() => {
+              canvas.current.clearCanvas();
+              setInputStrokes(0);
+              setReadOnly(false);
+              setKanjiGrade({
+                overallGrade: -1,
+                overallFeedback: "",
+                grades: [],
+                feedback: [],
+                strokeInfo: [],
+              });
+            }}
+          >
+            <AutorenewIcon fontSize="medium" />
+          </button>
+          :
+          <button
+            className="check-kanji"
+            style={styles.button}
+            onClick={() => {
+              if (document.getElementById("react-sketch-canvas")?.getElementsByTagName("path").length) {
+                setReadOnly(true);
+                canvas.current.exportSvg().then((data: any) => {
 
-        { kanji_grade.overallGrade !== -1 ?
-        <button
-        className="check-kanji"
-        style={styles.button}
-        onClick={() => {
-          canvas.current.clearCanvas();
-          setInputStrokes(0);
-          setReadOnly(false);
-          setKanjiGrade({
-            overallGrade: -1,
-            overallFeedback: "",
-            grades: [],
-            feedback: [],
-            strokeInfo: [],
-          });
-        }}
-        >
-           <AutorenewIcon fontSize="medium"/>
-        </button>
-        :
-        <button
-          className="check-kanji"
-          style={styles.button}
-          onClick={() => {
-            if (document.getElementById("react-sketch-canvas")?.getElementsByTagName("path").length) {
-              setReadOnly(true);
-              canvas.current.exportSvg().then((data: any) => {
-
-                const convertCoords = (coords: any) => {
-                  let coordsArr: any[] = []
-                  Object.keys(coords).map((key: string) => parseInt(key)).sort((a, b) => a - b).forEach((coordKey) => {
-                      coordsArr.push(coords[coordKey].map((coordsSet: {x: number, y:number}) => [coordsSet.x,coordsSet.y]))
-                  })
-                  return coordsArr;
-              }
-                grade(data, kanji, passing, convertCoords(character?.coords),character?.totalLengths).then((grade: KanjiGrade) => {
+                  const convertCoords = (coords: any) => {
+                    let coordsArr: any[] = []
+                    Object.keys(coords).map((key: string) => parseInt(key)).sort((a, b) => a - b).forEach((coordKey) => {
+                      coordsArr.push(coords[coordKey].map((coordsSet: { x: number, y: number }) => [coordsSet.x, coordsSet.y]))
+                    })
+                    return coordsArr;
+                  }
+                  grade(data, kanji, passing, convertCoords(character?.coords), character?.totalLengths).then((grade: KanjiGrade) => {
 
                 setKanjiGrade(grade)
                   setAttempts((prevAttempts) => {
@@ -400,24 +399,16 @@ const Draw: React.FC<DrawProps> = (props) => {
                     if(props.character.unicode_str) {
                       handleUpsertCharacterScoreData(props.character.unicode_str, grade.overallGrade)
                     }
-                    setAttempts((prevAttempts) => [...prevAttempts, grade])
-                    if (props.character) {
-                      if (props.handleComplete) {
-                        props.handleComplete(props.character, grade)
-                      }
-                      if (props.character.unicode_str) {
-                        handleUpsertCharacterScoreData(props.character.unicode_str, grade.overallGrade)
-                      }
-                      else {
-                        console.log("Character score not saved..")
-                      }
-
+                    else {
+                      console.log("Character score not saved..")
                     }
-
-
-                    if (grade.overallGrade < 65 || grade.overallGrade === -1 || !grade.overallGrade) {
-                      canvas.current.exportImage('jpeg').then((data: any) => {
-                        interpretImage(data).then(result => {
+                    
+                  }
+                  
+                  
+                  if (grade.overallGrade < 65 || grade.overallGrade === -1 || !grade.overallGrade) {
+                    canvas.current.exportImage('jpeg').then((data: any) => {
+                      interpretImage(data).then(result => {
 
                           console.log("Predictions:", result);
 

--- a/src/pages/Draw.tsx
+++ b/src/pages/Draw.tsx
@@ -366,7 +366,6 @@ const Draw: React.FC<DrawProps> = (props) => {
                       const some = attempts.some((grade) => grade.overallGrade > 65 && !grade.hint)
                       if(!some) {
                         if(allowDisplaySVG) {
-                          debugger;
                           if(grade.overallGrade > 65) {
                             setAllowDisplaySVG(false)
                             setDisplaySVG(false)
@@ -374,13 +373,11 @@ const Draw: React.FC<DrawProps> = (props) => {
                           
                         }
                         else {
-                          debugger;
                           setAllowDisplaySVG(true)
                           setDisplaySVG(true)
                         }
                       }
                       else {
-                        debugger;
                         setAllowDisplaySVG(true)
                         setDisplaySVG(true)
                       }


### PR DESCRIPTION
Old Functionality
If you passed at all, and you have completed two attempts, you can go forward.

New Functionality
Start off with being able to display the svg.
If you fail, repeat the drawing with the svg hint.
If you pass, you must draw the kanji again without the svg.
If you cannot draw the kanji without the svg, the cycle restarts.
If you pass, you can advance.

If you passed at all without a hint (displaying svg), then you can go forward and display svg stays available after each attempt.



https://github.com/Gpresent/BrushPath/assets/63921108/09962bd8-421e-4dd6-bc9f-f1422c4e2cf4

